### PR TITLE
Fix GZIP & Add ZSTD Decompression

### DIFF
--- a/transport.go
+++ b/transport.go
@@ -32,6 +32,7 @@ import (
 	"time"
 
 	"github.com/andybalholm/brotli"
+	"github.com/klauspost/compress/zstd"
 
 	tls "github.com/Noooste/utls"
 
@@ -2566,6 +2567,11 @@ func (pc *persistConn) roundTrip(req *transportRequest) (resp *Response, err err
 		req.extraHeaders().Set("Accept-Encoding", "gzip, deflate, br")
 	}
 
+	// Set gzip to true if the caller's Accept-Encoding includes gzip.
+	if strings.Contains(req.Header.Get("Accept-Encoding"), "gzip") || strings.Contains(req.Header.get("accept-encoding"), "gzip") {
+		requestedGzip = true
+	}
+
 	var continueCh chan struct{}
 	if req.ProtoAtLeast(1, 1) && req.Body != nil && req.expectsContinue() {
 		continueCh = make(chan struct{}, 1)
@@ -2886,9 +2892,44 @@ func DecompressBodyByType(body io.ReadCloser, contentType string) io.ReadCloser 
 		}
 	case "deflate":
 		return identifyDeflate(body)
+	case "zstd":
+		return &zstdReader{
+			body: body,
+		}
 	default:
 		return body
 	}
+}
+
+// zstdReader wraps a response body so it can lazily
+// call zstd.NewReader on the first call to Read
+type zstdReader struct {
+	body io.ReadCloser // underlying Response.Body
+	zr   *zstd.Decoder // lazily-initialized zstd reader
+	zerr error         // sticky error
+}
+
+func (zs *zstdReader) Read(p []byte) (n int, err error) {
+	if zs.zerr != nil {
+		return 0, zs.zerr
+	}
+	if zs.zr == nil {
+		zs.zr, err = zstd.NewReader(zs.body)
+		if err != nil {
+			zs.zerr = err
+			return 0, err
+		}
+	}
+	return zs.zr.Read(p)
+}
+
+func (zs *zstdReader) Close() error {
+	if zs.zr != nil {
+		zs.zr.Close() // zs.zr.Close() does not return a value, hence it's not checked for an error
+	}
+
+	// Close body and return error
+	return zs.body.Close()
 }
 
 // gzipReader wraps a response body so it can lazily


### PR DESCRIPTION
Sometimes GZIP responses arent unzipped due to how they are handled, this fix ensures they are properly unzipped, and also adds ZSTD compression ability.